### PR TITLE
Make it possible to provision private ssh key as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Launching an instance with the following as userdata will create users
     }
 
 This userdata points to the bucket keys.30mhz.com, and expects an object with the name `jasper@9apps.net`, for the key of the user `jasper`.
+If the bucket has an object with the name `jasper@9apps.net.private` this file will be installed as a private ssh key for the user `jasper`.
 
 ## Requirements
 
@@ -86,5 +87,6 @@ User accounts on instances in most systems are only used for (administering) acc
 * full name (comment)
 * groups
 * authorized keys
+* private key (optional)
 
-We put username, email, full name and groups in userdata. Authorized keys are stored in S3, in objects with the email as their key name.
+We put username, email, full name and groups in userdata. Authorized and private keys are stored in S3, in objects with the email as their key name.

--- a/users
+++ b/users
@@ -44,10 +44,11 @@ if "provision" == sys.argv[1]:
 		key.get_contents_to_filename(
 							"/home/{0}/.ssh/authorized_keys".format(username))
 		try:
-			key.key = "{0}.private".fromat(user['email'])
+			key.key = "{0}.private".format(user['email'])
 			key.exists()
 			key.get_contents_to_filename(
 							"/home/{0}/.ssh/id_rsa".format(username))
+			os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
 		except:
 			sys.stdout.write(" {0} has no private key to provision".format(username))
 
@@ -74,10 +75,11 @@ elif "update" == sys.argv[1]:
 			os.remove("/home/{0}/.ssh/authorized_keys".format(username))
 
 		try:
-			key.key = "{0}.private".fromat(user['email'])
+			key.key = "{0}.private".format(user['email'])
 			key.exists()
 			key.get_contents_to_filename(
 							"/home/{0}/.ssh/id_rsa".format(username))
+			os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
 		except:
 			# also remove
 			os.remove("/home/{0}/.ssh/id_rsa".format(username))

--- a/users
+++ b/users
@@ -43,6 +43,14 @@ if "provision" == sys.argv[1]:
 		os.system("/bin/mkdir --mode=0700 -p /home/{0}/.ssh".format(username))
 		key.get_contents_to_filename(
 							"/home/{0}/.ssh/authorized_keys".format(username))
+		try:
+			key.key = "{0}.private".fromat(user['email'])
+			key.exists()
+			key.get_contents_to_filename(
+							"/home/{0}/.ssh/id_rsa".format(username))
+		except:
+			sys.stdout.write(" {0} has no private key to provision".format(username))
+
 		os.system("chown -R {0}.{0} /home/{0}".format(username))
 elif "remove" == sys.argv[1]:
 	for username in userdata['security']['users']:
@@ -64,6 +72,15 @@ elif "update" == sys.argv[1]:
 							"/home/{0}/.ssh/authorized_keys".format(username))
 		except:
 			os.remove("/home/{0}/.ssh/authorized_keys".format(username))
+
+		try:
+			key.key = "{0}.private".fromat(user['email'])
+			key.exists()
+			key.get_contents_to_filename(
+							"/home/{0}/.ssh/id_rsa".format(username))
+		except:
+			# also remove
+			os.remove("/home/{0}/.ssh/id_rsa".format(username))
 
 		os.system("chown -R {0}.{0} /home/{0}".format(username))
 else:

--- a/users
+++ b/users
@@ -40,7 +40,7 @@ if "provision" == sys.argv[1]:
 											username))
 
 		key.key = user['email']
-		os.system("/bin/mkdir --mode=0755 -p /home/{0}/.ssh".format(username))
+		os.system("/bin/mkdir --mode=0700 -p /home/{0}/.ssh".format(username))
 		key.get_contents_to_filename(
 							"/home/{0}/.ssh/authorized_keys".format(username))
 		os.system("chown -R {0}.{0} /home/{0}".format(username))

--- a/users
+++ b/users
@@ -28,6 +28,7 @@ if not ('security' in userdata and 'users' in userdata['security']):
 s3 = boto.connect_s3()
 keys = s3.get_bucket(userdata['security']['bucket'], validate=False)
 key = boto.s3.key.Key(keys)
+privatekey = boto.s3.key.Key(keys)
 
 if "provision" == sys.argv[1]:
 	for username in userdata['security']['users']:
@@ -44,9 +45,8 @@ if "provision" == sys.argv[1]:
 		key.get_contents_to_filename(
 							"/home/{0}/.ssh/authorized_keys".format(username))
 		try:
-			key.key = "{0}.private".format(user['email'])
-			key.exists()
-			key.get_contents_to_filename(
+			privatekey.key = "{0}.private".format(user['email'])
+			privatekey.get_contents_to_filename(
 							"/home/{0}/.ssh/id_rsa".format(username))
 			os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
 		except:
@@ -75,9 +75,9 @@ elif "update" == sys.argv[1]:
 			os.remove("/home/{0}/.ssh/authorized_keys".format(username))
 
 		try:
-			key.key = "{0}.private".format(user['email'])
-			key.exists()
-			key.get_contents_to_filename(
+			privatekey.key = "{0}.private".format(user['email'])
+			privatekey.exists()
+			privatekey.get_contents_to_filename(
 							"/home/{0}/.ssh/id_rsa".format(username))
 			os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
 		except:

--- a/users_ubuntu
+++ b/users_ubuntu
@@ -44,7 +44,7 @@ if "provision" == sys.argv[1]:
                 os.system(command)
 
                 key.key = user['email']
-                os.system("/bin/mkdir --mode=0755 -p /home/{0}/.ssh".format(username))
+                os.system("/bin/mkdir --mode=0700 -p /home/{0}/.ssh".format(username))
                 key.get_contents_to_filename(
                                                         "/home/{0}/.ssh/authorized_keys".format(username))
                 os.system("chown -R {0}.{0} /home/{0}".format(username))

--- a/users_ubuntu
+++ b/users_ubuntu
@@ -47,6 +47,14 @@ if "provision" == sys.argv[1]:
                 os.system("/bin/mkdir --mode=0700 -p /home/{0}/.ssh".format(username))
                 key.get_contents_to_filename(
                                                         "/home/{0}/.ssh/authorized_keys".format(username))
+                try:
+                        key.key = "{0}.private".fromat(user['email'])
+                        key.exists()
+                        key.get_contents_to_filename(
+                                                        "/home/{0}/.ssh/id_rsa".format(username))
+                except:
+                        sys.stdout.write(" {0} has no private key to provision".format(username))
+
                 os.system("chown -R {0}.{0} /home/{0}".format(username))
 elif "remove" == sys.argv[1]:
         for username in userdata['security']['users']:
@@ -68,6 +76,14 @@ elif "update" == sys.argv[1]:
                                                         "/home/{0}/.ssh/authorized_keys".format(username))
                 except:
                         os.remove("/home/{0}/.ssh/authorized_keys".format(username))
+                try:
+                        key.key = "{0}.private".fromat(user['email'])
+                        key.exists()
+                        key.get_contents_to_filename(
+                                                        "/home/{0}/.ssh/id_rsa".format(username))
+                except:
+                        # also remove
+                        os.remove("/home/{0}/.ssh/id_rsa".format(username))
 
                 os.system("chown -R {0}.{0} /home/{0}".format(username))
 else:

--- a/users_ubuntu
+++ b/users_ubuntu
@@ -48,10 +48,11 @@ if "provision" == sys.argv[1]:
                 key.get_contents_to_filename(
                                                         "/home/{0}/.ssh/authorized_keys".format(username))
                 try:
-                        key.key = "{0}.private".fromat(user['email'])
+                        key.key = "{0}.private".format(user['email'])
                         key.exists()
                         key.get_contents_to_filename(
                                                         "/home/{0}/.ssh/id_rsa".format(username))
+                        os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
                 except:
                         sys.stdout.write(" {0} has no private key to provision".format(username))
 
@@ -77,10 +78,11 @@ elif "update" == sys.argv[1]:
                 except:
                         os.remove("/home/{0}/.ssh/authorized_keys".format(username))
                 try:
-                        key.key = "{0}.private".fromat(user['email'])
+                        key.key = "{0}.private".format(user['email'])
                         key.exists()
                         key.get_contents_to_filename(
                                                         "/home/{0}/.ssh/id_rsa".format(username))
+                        os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
                 except:
                         # also remove
                         os.remove("/home/{0}/.ssh/id_rsa".format(username))

--- a/users_ubuntu
+++ b/users_ubuntu
@@ -30,6 +30,7 @@ if not ('security' in userdata and 'users' in userdata['security']):
 s3 = boto.connect_s3()
 keys = s3.get_bucket(userdata['security']['bucket'], validate=False)
 key = boto.s3.key.Key(keys)
+privatekey = boto.s3.key.Key(keys)
 
 if "provision" == sys.argv[1]:
         for username in userdata['security']['users']:
@@ -48,9 +49,8 @@ if "provision" == sys.argv[1]:
                 key.get_contents_to_filename(
                                                         "/home/{0}/.ssh/authorized_keys".format(username))
                 try:
-                        key.key = "{0}.private".format(user['email'])
-                        key.exists()
-                        key.get_contents_to_filename(
+                        privatekey.key = "{0}.private".format(user['email'])
+                        privatekey.get_contents_to_filename(
                                                         "/home/{0}/.ssh/id_rsa".format(username))
                         os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
                 except:
@@ -78,9 +78,9 @@ elif "update" == sys.argv[1]:
                 except:
                         os.remove("/home/{0}/.ssh/authorized_keys".format(username))
                 try:
-                        key.key = "{0}.private".format(user['email'])
-                        key.exists()
-                        key.get_contents_to_filename(
+                        privatekey.key = "{0}.private".format(user['email'])
+                        privatekey.exists()
+                        privatekey.get_contents_to_filename(
                                                         "/home/{0}/.ssh/id_rsa".format(username))
                         os.system("chmod 600 /home/{0}/.ssh/id_rsa".format(username))
                 except:


### PR DESCRIPTION
Sometimes you want a provisioned user to have a private ssh key as well.

For example, our usecase is that we provision a user for our CI setup. When the instance is up and the users are installed, it is automatically added as slave to our jenkins setup. Since this slave has to checkout private git repositories, (not as start of the task, but as composer within the build process) it needs a private key.

Adding the private key is as simple as uploading a file to the keys bucket in the format: jasper@9apps.net.private

Cheers,
