### PR TITLE
Skip SSL Certificate validation

### DIFF
--- a/users
+++ b/users
@@ -12,12 +12,13 @@
 . /etc/init.d/functions
 
 manage=$(cat<<EOF
-import sys
-import os
-import pwd
-import json
 import boto
 import boto.utils
+import json
+import os
+import pwd
+import ssl
+import sys
 
 userdata = json.loads(boto.utils.get_instance_userdata())
 
@@ -25,6 +26,11 @@ userdata = json.loads(boto.utils.get_instance_userdata())
 if not ('security' in userdata and 'users' in userdata['security']):
 	exit(0)
 
+# Buckets with a . in their name do not have
+# a valid ssl cert (*.s3.amazonaws.com)
+# Create ssl context that does not validate certificates
+if hasattr(ssl, '_create_unverified_context'):
+	ssl._create_default_https_context = ssl._create_unverified_context
 s3 = boto.connect_s3()
 keys = s3.get_bucket(userdata['security']['bucket'], validate=False)
 key = boto.s3.key.Key(keys)

--- a/users_ubuntu
+++ b/users_ubuntu
@@ -14,12 +14,13 @@
 . /lib/lsb/init-functions
 
 manage=$(cat<<EOF
-import sys
-import os
-import pwd
-import json
 import boto
 import boto.utils
+import json
+import os
+import pwd
+import ssl
+import sys
 
 userdata = json.loads(boto.utils.get_instance_userdata())
 
@@ -27,6 +28,11 @@ userdata = json.loads(boto.utils.get_instance_userdata())
 if not ('security' in userdata and 'users' in userdata['security']):
         exit(0)
 
+# Buckets with a . in their name do not have
+# a valid ssl cert (*.s3.amazonaws.com)
+# Create ssl context that does not validate certificates
+if hasattr(ssl, '_create_unverified_context'):
+        ssl._create_default_https_context = ssl._create_unverified_context
 s3 = boto.connect_s3()
 keys = s3.get_bucket(userdata['security']['bucket'], validate=False)
 key = boto.s3.key.Key(keys)


### PR DESCRIPTION
In the readme you describe a bucket name with dots (.).
With newer python 2.7 this will fail as python cannot validate the certificate.
Hostname is keys.30mhz.com.s3.amazonaws.com while the certificate is for *.s3.amazonaws.com.

See https://github.com/boto/boto/issues/2836

This patch creates an SSL context that does not do certificate validation.
